### PR TITLE
[FIX] Correct reference to layer file

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 
 
     # Mesh on 8 cores, use True to use all cores
-    cloudpath = config['cloudpath']
+    cloudpath = config['layer']
     tq = LocalTaskQueue(parallel=True)
 
     tasks = tc.create_meshing_tasks(cloudpath, mip=config['mip'], shape=tuple(config['shape']))


### PR DESCRIPTION
`cloudpath` is just a reference to Brainlife to link datasets and apps, but the actual file path is in `layer`

<img width="191" height="68" alt="image" src="https://github.com/user-attachments/assets/0f886bf8-0a1f-4bb1-bb2e-69f42b0a86e3" />

<img width="888" height="129" alt="image" src="https://github.com/user-attachments/assets/efac7446-902f-47f8-93ab-c312b629421c" />
